### PR TITLE
added margin-top: 50px; to .filter-container within _home.scss

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -105,6 +105,7 @@ a:hover {
   justify-content: center;
   position: static;
   top: 50%;
+  margin-top: 50px;
 }
 
 p {


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2023-06-06 at 8 39 35 PM" src="https://github.com/Version-LAA/techtrek/assets/122124504/6015fd76-5d3c-4efe-aad5-b58384733377">

Added margin since on my mac it was showing weirdly. Will look better for the demo ✅